### PR TITLE
Fix broken Star History chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -806,7 +806,7 @@ The survey paper (`paper/`) is **All Rights Reserved** — copyright belongs to 
 
 ## ✨ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=PolyX-Research/Awesome-Remote-Sensing-Agents&type=date&legend=top-left)](https://www.star-history.com/#PolyX-Research/Awesome-Remote-Sensing-Agents&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=PolyX-Research/Awesome-Remote-Sensing-Agents&type=date&legend=top-left)](https://star-history.dera.page/#PolyX-Research/Awesome-Remote-Sensing-Agents&type=date&legend=top-left)
 
 
 ## ✉️ Contact


### PR DESCRIPTION
The Star History chart in the README no longer renders because the current endpoint is affected by GitHub stargazer API restrictions. This PR switches it to a working mirror so visitors can still see the repository's star growth. No other changes are made.